### PR TITLE
Sync server projects widget

### DIFF
--- a/openpype/modules/default_modules/sync_server/sync_server_module.py
+++ b/openpype/modules/default_modules/sync_server/sync_server_module.py
@@ -815,17 +815,22 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
     def _prepare_sync_project_settings(self, exclude_locals):
         sync_project_settings = {}
         system_sites = self.get_all_site_configs()
-        for collection in self.connection.database.collection_names(False):
+        project_docs = self.connection.projects(
+            projection={"name": 1},
+            only_active=True
+        )
+        for project_doc in project_docs:
+            project_name = project_doc["name"]
             sites = copy.deepcopy(system_sites)  # get all configured sites
             proj_settings = self._parse_sync_settings_from_settings(
-                get_project_settings(collection,
+                get_project_settings(project_name,
                                      exclude_locals=exclude_locals))
             sites.update(self._get_default_site_configs(
-                proj_settings["enabled"], collection))
+                proj_settings["enabled"], project_name))
             sites.update(proj_settings['sites'])
             proj_settings["sites"] = sites
 
-            sync_project_settings[collection] = proj_settings
+            sync_project_settings[project_name] = proj_settings
         if not sync_project_settings:
             log.info("No enabled and configured projects for sync.")
         return sync_project_settings

--- a/openpype/modules/default_modules/sync_server/tray/app.py
+++ b/openpype/modules/default_modules/sync_server/tray/app.py
@@ -77,8 +77,8 @@ class SyncServerWindow(QtWidgets.QDialog):
         self.setWindowTitle("Sync Queue")
 
         self.projects.project_changed.connect(
-            lambda: repres.table_view.model().set_project(
-                self.projects.current_project))
+            self._on_project_change
+        )
 
         self.pause_btn.clicked.connect(self._pause)
         self.pause_btn.setAutoDefault(False)
@@ -86,6 +86,13 @@ class SyncServerWindow(QtWidgets.QDialog):
         repres.message_generated.connect(self._update_message)
 
         self.representationWidget = repres
+
+    def _on_project_change(self):
+        if self.projects.current_project is None:
+            return
+        self.representationWidget.table_view.model().set_project(
+            self.projects.current_project
+        )
 
     def showEvent(self, event):
         self.representationWidget.model.set_project(

--- a/openpype/modules/default_modules/sync_server/tray/models.py
+++ b/openpype/modules/default_modules/sync_server/tray/models.py
@@ -17,25 +17,6 @@ from . import lib
 log = PypeLogger().get_logger("SyncServer")
 
 
-class ProjectModel(QtCore.QAbstractListModel):
-    def __init__(self, *args, projects=None, **kwargs):
-        super(ProjectModel, self).__init__(*args, **kwargs)
-        self.projects = projects or []
-
-    def data(self, index, role):
-        if role == Qt.DisplayRole:
-            # See below for the data structure.
-            status, text = self.projects[index.row()]
-            # Return the todo text only.
-            return text
-
-    def rowCount(self, _index):
-        return len(self.todos)
-
-    def columnCount(self, _index):
-        return len(self._header)
-
-
 class _SyncRepresentationModel(QtCore.QAbstractTableModel):
 
     COLUMN_LABELS = []


### PR DESCRIPTION
## Changes
- sync server is not using widget from settings as is using only very limited logic from it (only initialization and only few lines)
- only_active is handled in inner sync server module logic (which also defines which projects are shown in UI)
- removed unused `ProjectModel`

## Notes
- there are few irrelevant parts of code in sync server widget but they were there before too